### PR TITLE
fix(ci): correct source repo to vaultai-code

### DIFF
--- a/get_repo.sh
+++ b/get_repo.sh
@@ -29,7 +29,7 @@ mkdir -p vscode
 cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
 git init -q
-git remote add origin https://github.com/VaultAI-EU/void.git
+git remote add origin https://github.com/VaultAI-EU/vaultai-code.git
 
 # Allow callers to specify a particular commit to checkout via the
 # environment variable VOID_COMMIT.  We still default to the tip of the


### PR DESCRIPTION
Replace URL to clone VaultAI-EU/vaultai-code instead of VaultAI-EU/void in get_repo.sh