### PR TITLE
ci(windows): use windows-2022 runner

### DIFF
--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -157,7 +157,7 @@ jobs:
     needs:
       - check
       - compile
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -29,7 +29,7 @@ mkdir -p vscode
 cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
 git init -q
-git remote add origin https://github.com/VaultAI-EU/void.git
+git remote add origin https://github.com/VaultAI-EU/vaultai-code.git
 
 # Allow callers to specify a particular commit to checkout via the
 # environment variable VOID_COMMIT.  We still default to the tip of the


### PR DESCRIPTION
Windows Server 2019 retired; switch to windows-2022 (windows-latest also OK).